### PR TITLE
Updated benchmarks to profile only the routers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This are several benchmarks made to see how YARF performs under different conditions and compared against other similar frameworks. 
 
+Note: Running the benchmarks will need at least 14GB of free memory.
 
 ### Frameworks used for comparison 
 
@@ -19,6 +20,10 @@ This are several benchmarks made to see how YARF performs under different condit
 To run the benchmarks yourself simply clone this repository, step into the root directory and run:
 
 ```
+ # CPU profiling
+ go test -bench .
+
+ # Memory profiling
  go test -benchmem -bench .
 ```
 
@@ -26,26 +31,25 @@ To run the benchmarks yourself simply clone this repository, step into the root 
 ### Benchmark results (totally subjective to local hardware configuration)
 
 ```
-BenchmarkMultiYarf-8             100      15852647 ns/op     4149288 B/op      90605 allocs/op
-BenchmarkMultiHttpRouter-8       100      12663773 ns/op     4249047 B/op      80000 allocs/op
-BenchmarkMultiGoji-8             100      18221827 ns/op     6330477 B/op      90004 allocs/op
-BenchmarkMultiGorilla-8           30      43548624 ns/op    13142176 B/op     240015 allocs/op
-BenchmarkMultiMartini-8           20      56270002 ns/op    16202178 B/op     220022 allocs/op
-BenchmarkMultiGin-8              100      13578911 ns/op     3129951 B/op      80002 allocs/op
-BenchmarkMultiPat-8              100      19447168 ns/op     5556713 B/op     140004 allocs/op
-BenchmarkParamYarf-8         3000000           419 ns/op         153 B/op          3 allocs/op
-BenchmarkParamHttpRouter-8  10000000           211 ns/op          79 B/op          2 allocs/op
-BenchmarkParamGoji-8         2000000           624 ns/op         390 B/op          3 allocs/op
-BenchmarkParamGorilla-8      1000000          2187 ns/op         886 B/op         12 allocs/op
-BenchmarkParamMartini-8       300000          4096 ns/op        1265 B/op         16 allocs/op
-BenchmarkParamGin-8          5000000           330 ns/op          63 B/op          2 allocs/op
-BenchmarkParamPat-8          1000000          1059 ns/op         315 B/op          8 allocs/op
-BenchmarkSimpleYarf-8        5000000           358 ns/op         159 B/op          3 allocs/op
-BenchmarkSimpleHttpRouter-8 20000000            87.5 ns/op        47 B/op          1 allocs/op
-BenchmarkSimpleGoji-8       10000000           224 ns/op          47 B/op          1 allocs/op
-BenchmarkSimpleGorilla-8     1000000          1385 ns/op         535 B/op          9 allocs/op
-BenchmarkSimpleMartini-8      500000          3393 ns/op         888 B/op         12 allocs/op
-BenchmarkSimpleGin-8         5000000           237 ns/op          47 B/op          1 allocs/op
-BenchmarkSimplePat-8        10000000           178 ns/op          95 B/op          2 allocs/op
-
+BenchmarkMultiYarf-8             500000    3457 ns/op    1127 B/op    13 allocs/op
+BenchmarkMultiHttpRouter-8      3000000     692 ns/op     221 B/op     2 allocs/op
+BenchmarkMultiGoji-8            1000000    1202 ns/op     425 B/op     3 allocs/op
+BenchmarkMultiGorilla-8          200000    5257 ns/op    1088 B/op    18 allocs/op
+BenchmarkMultiMartini-8          200000    5529 ns/op    1376 B/op    16 allocs/op
+BenchmarkMultiGin-8             2000000     965 ns/op     446 B/op     3 allocs/op
+BenchmarkMultiPat-8             1000000    1399 ns/op     624 B/op     9 allocs/op
+BenchmarkParamYarf-8            3000000     491 ns/op     144 B/op     3 allocs/op
+BenchmarkParamHttpRouter-8     10000000     229 ns/op      48 B/op     2 allocs/op
+BenchmarkParamGoji-8            2000000     610 ns/op     352 B/op     3 allocs/op
+BenchmarkParamGorilla-8          500000    2615 ns/op     848 B/op    12 allocs/op
+BenchmarkParamMartini-8          300000    4381 ns/op    1232 B/op    16 allocs/op
+BenchmarkParamGin-8             2000000     504 ns/op     384 B/op     3 allocs/op
+BenchmarkParamPat-8             1000000    1438 ns/op     624 B/op     9 allocs/op
+BenchmarkSimpleYarf-8           3000000     433 ns/op     144 B/op     3 allocs/op
+BenchmarkSimpleHttpRouter-8    20000000     109 ns/op      16 B/op     1 allocs/op
+BenchmarkSimpleGoji-8           5000000     260 ns/op      16 B/op     1 allocs/op
+BenchmarkSimpleGorilla-8        1000000    1410 ns/op     496 B/op     9 allocs/op
+BenchmarkSimpleMartini-8         300000    4076 ns/op     848 B/op    12 allocs/op
+BenchmarkSimpleGin-8            3000000     416 ns/op     368 B/op     2 allocs/op
+BenchmarkSimplePat-8           10000000     198 ns/op      64 B/op     2 allocs/op
 ```

--- a/simple_test.go
+++ b/simple_test.go
@@ -45,16 +45,34 @@ func GinHello(c *gin.Context) {
 	c.String(200, "Hello world!")
 }
 
+func generateSimpleRequests(b *testing.B) ([]*httptest.ResponseRecorder, []*http.Request) {
+	responses := make([]*httptest.ResponseRecorder, b.N)
+	requests := make([]*http.Request, b.N)
+
+	for i := 0; i < b.N; i++ {
+		responses[i] = httptest.NewRecorder()
+
+		req, err := http.NewRequest("GET", "http://localhost:8080/", nil)
+		if err != nil {
+			b.Logf("got unexpected error: %q", err.Error())
+			b.Fail()
+		}
+		requests[i] = req
+	}
+
+	return responses, requests
+}
+
 // Benchmarks
 func BenchmarkSimpleYarf(b *testing.B) {
 	y := yarf.New()
 	y.Add("/", new(YarfHello))
 
-	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
-	res := httptest.NewRecorder()
+	responses, requests := generateSimpleRequests(b)
+	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		y.ServeHTTP(res, req)
+		y.ServeHTTP(responses[i], requests[i])
 	}
 }
 
@@ -62,12 +80,11 @@ func BenchmarkSimpleHttpRouter(b *testing.B) {
 	router := httprouter.New()
 	router.GET("/", HttpRouterHello)
 
-	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
-	res := httptest.NewRecorder()
+	responses, requests := generateSimpleRequests(b)
+	b.ResetTimer()
 
-	// Run benchmark
 	for i := 0; i < b.N; i++ {
-		router.ServeHTTP(res, req)
+		router.ServeHTTP(responses[i], requests[i])
 	}
 }
 
@@ -75,12 +92,11 @@ func BenchmarkSimpleGoji(b *testing.B) {
 	g := web.New()
 	g.Get("/", GojiHello)
 
-	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
-	res := httptest.NewRecorder()
+	responses, requests := generateSimpleRequests(b)
+	b.ResetTimer()
 
-	// Run benchmark
 	for i := 0; i < b.N; i++ {
-		g.ServeHTTP(res, req)
+		g.ServeHTTP(responses[i], requests[i])
 	}
 }
 
@@ -88,12 +104,11 @@ func BenchmarkSimpleGorilla(b *testing.B) {
 	m := mux.NewRouter()
 	m.HandleFunc("/", HttpHello)
 
-	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
-	res := httptest.NewRecorder()
+	responses, requests := generateSimpleRequests(b)
+	b.ResetTimer()
 
-	// Run benchmark
 	for i := 0; i < b.N; i++ {
-		m.ServeHTTP(res, req)
+		m.ServeHTTP(responses[i], requests[i])
 	}
 }
 
@@ -103,12 +118,11 @@ func BenchmarkSimpleMartini(b *testing.B) {
 	r.Get("/", HttpHello)
 	m.Action(r.Handle)
 
-	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
-	res := httptest.NewRecorder()
+	responses, requests := generateSimpleRequests(b)
+	b.ResetTimer()
 
-	// Run benchmark
 	for i := 0; i < b.N; i++ {
-		m.ServeHTTP(res, req)
+		m.ServeHTTP(responses[i], requests[i])
 	}
 }
 
@@ -118,12 +132,11 @@ func BenchmarkSimpleGin(b *testing.B) {
 	r := gin.New()
 	r.GET("/", GinHello)
 
-	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
-	res := httptest.NewRecorder()
+	responses, requests := generateSimpleRequests(b)
+	b.ResetTimer()
 
-	// Run benchmark
 	for i := 0; i < b.N; i++ {
-		r.ServeHTTP(res, req)
+		r.ServeHTTP(responses[i], requests[i])
 	}
 }
 
@@ -131,11 +144,10 @@ func BenchmarkSimplePat(b *testing.B) {
 	m := pat.New()
 	m.Get("/", http.HandlerFunc(HttpHello))
 
-	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
-	res := httptest.NewRecorder()
+	responses, requests := generateSimpleRequests(b)
+	b.ResetTimer()
 
-	// Run benchmark
 	for i := 0; i < b.N; i++ {
-		m.ServeHTTP(res, req)
+		m.ServeHTTP(responses[i], requests[i])
 	}
 }

--- a/single_test.go
+++ b/single_test.go
@@ -1,8 +1,6 @@
 package benchmarks
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/yarf-framework/yarf"
@@ -23,10 +21,10 @@ func BenchmarkSingleYarf(b *testing.B) {
 	y := yarf.New()
 	y.Add("/", new(YarfSingle))
 
-	req, _ := http.NewRequest("GET", "http://localhost:8080/", nil)
-	res := httptest.NewRecorder()
+	responses, requests := generateSimpleRequests(b)
+	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		y.ServeHTTP(res, req)
+		y.ServeHTTP(responses[i], requests[i])
 	}
 }


### PR DESCRIPTION
This updates (corrects) the benchmarks to profile only the routers not anything else.
It also allows the tests to respect the number of iterations set by the testing framework so that they are predictable.
Also separate response recorders are needed so that the responses are correctly written from the requests.
If merged, this change will require a lot more memory to be used by the tests since the requests and response recorders are pre-allocated based on the number of iterations. On my machine I need about 14GB of free memory for them to fully run (mainly because of BenchmarkSimpleHttpRouter which has 20 million iterations)

The numbers in the README are those that I see on my machine, the numbers when running the tests against master (e5268fb44ff5f221c19a85bff2ea27d8ac2ed369) are:

```
BenchmarkMultiYarf-8                100    16524092 ns/op       4325135 B/op     91006 allocs/op
BenchmarkMultiHttpRouter-8          100    12675113 ns/op       4249049 B/op     80000 allocs/op
BenchmarkMultiGoji-8                100    17905547 ns/op       6330454 B/op     90004 allocs/op
BenchmarkMultiGorilla-8              30    43901071 ns/op      13142176 B/op    240015 allocs/op
BenchmarkMultiMartini-8              30    55775966 ns/op      16029548 B/op    220018 allocs/op
BenchmarkMultiGin-8                 100    13487695 ns/op       3129929 B/op     80002 allocs/op
BenchmarkMultiPat-8                 100    19322855 ns/op       5556662 B/op    140004 allocs/op
BenchmarkParamYarf-8            3000000         440 ns/op           169 B/op         3 allocs/op
BenchmarkParamHttpRouter-8     10000000         202 ns/op            79 B/op         2 allocs/op
BenchmarkParamGoji-8            2000000         630 ns/op           390 B/op         3 allocs/op
BenchmarkParamGorilla-8         1000000        2212 ns/op           886 B/op        12 allocs/op
BenchmarkParamMartini-8          300000        4085 ns/op          1265 B/op        16 allocs/op
BenchmarkParamGin-8             5000000         328 ns/op            63 B/op         2 allocs/op
BenchmarkParamPat-8             1000000        1053 ns/op           315 B/op         8 allocs/op
BenchmarkSimpleYarf-8           3000000         387 ns/op           170 B/op         3 allocs/op
BenchmarkSimpleHttpRouter-8    20000000          82.1 ns/op          47 B/op         1 allocs/op
BenchmarkSimpleGoji-8          10000000         219 ns/op            47 B/op         1 allocs/op
BenchmarkSimpleGorilla-8        1000000        1399 ns/op           535 B/op         9 allocs/op
BenchmarkSimpleMartini-8         500000        3369 ns/op           888 B/op        12 allocs/op
BenchmarkSimpleGin-8            5000000         236 ns/op            47 B/op         1 allocs/op
BenchmarkSimplePat-8           10000000         182 ns/op            95 B/op         2 allocs/op
```

After applying the changes the results look like this:

```
BenchmarkMultiYarf-8             500000    3457 ns/op    1127 B/op    13 allocs/op
BenchmarkMultiHttpRouter-8      3000000     692 ns/op     221 B/op     2 allocs/op
BenchmarkMultiGoji-8            1000000    1202 ns/op     425 B/op     3 allocs/op
BenchmarkMultiGorilla-8          200000    5257 ns/op    1088 B/op    18 allocs/op
BenchmarkMultiMartini-8          200000    5529 ns/op    1376 B/op    16 allocs/op
BenchmarkMultiGin-8             2000000     965 ns/op     446 B/op     3 allocs/op
BenchmarkMultiPat-8             1000000    1399 ns/op     624 B/op     9 allocs/op
BenchmarkParamYarf-8            3000000     491 ns/op     144 B/op     3 allocs/op
BenchmarkParamHttpRouter-8     10000000     229 ns/op      48 B/op     2 allocs/op
BenchmarkParamGoji-8            2000000     610 ns/op     352 B/op     3 allocs/op
BenchmarkParamGorilla-8          500000    2615 ns/op     848 B/op    12 allocs/op
BenchmarkParamMartini-8          300000    4381 ns/op    1232 B/op    16 allocs/op
BenchmarkParamGin-8             2000000     504 ns/op     384 B/op     3 allocs/op
BenchmarkParamPat-8             1000000    1438 ns/op     624 B/op     9 allocs/op
BenchmarkSimpleYarf-8           3000000     433 ns/op     144 B/op     3 allocs/op
BenchmarkSimpleHttpRouter-8    20000000     109 ns/op      16 B/op     1 allocs/op
BenchmarkSimpleGoji-8           5000000     260 ns/op      16 B/op     1 allocs/op
BenchmarkSimpleGorilla-8        1000000    1410 ns/op     496 B/op     9 allocs/op
BenchmarkSimpleMartini-8         300000    4076 ns/op     848 B/op    12 allocs/op
BenchmarkSimpleGin-8            3000000     416 ns/op     368 B/op     2 allocs/op
BenchmarkSimplePat-8           10000000     198 ns/op      64 B/op     2 allocs/op
```

(updated due to copy-paste fail on my side, sorry)

Hope it helps.
